### PR TITLE
fix: update local server URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To start working on the project:
    pnpm dev
    ```
 
-   This will start a local server, typically at <http://localhost:3000> (check your terminal for the exact URL)
+   This will start a local server, typically at <http://localhost:5173> (check your terminal for the exact URL)
 
 2. **Make Changes**:
    - The site will automatically update when you make changes to the code


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the default local server URL from `http://localhost:3000` to `http://localhost:5173`.