### PR TITLE
fix: fake key on build time

### DIFF
--- a/src/routes/(egg)/egg/+page.server.ts
+++ b/src/routes/(egg)/egg/+page.server.ts
@@ -1,3 +1,4 @@
+import { building } from '$app/environment';
 import { env } from '$env/dynamic/private';
 import OpenAI from 'openai';
 import { zodResponseFormat } from 'openai/helpers/zod';
@@ -5,7 +6,7 @@ import { z } from 'zod';
 import data from './data.md?raw';
 
 const openai = new OpenAI({
-	apiKey: env.LLM_API_KEY,
+	apiKey: env.LLM_API_KEY || (building ? 'test' : undefined),
 	baseURL: env.LLM_BASE_URL
 });
 


### PR DESCRIPTION
This pull request makes a small adjustment to the `src/routes/(egg)/egg/+page.server.ts` file to improve the handling of the `apiKey` configuration for the OpenAI client.

* Updated the `apiKey` initialization to use a fallback value of `'test'` when the `LLM_API_KEY` environment variable is not set and the `building` flag is `true`.