### PR TITLE
fix: forcely enable dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -4,6 +4,8 @@
 @plugin 'flowbite/plugin';
 @source "../node_modules/flowbite-svelte/dist";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 html, body {
     overflow-x: hidden;
     width: 100%;

--- a/src/routes/(main)/+layout.svelte
+++ b/src/routes/(main)/+layout.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <div
-	class="flex min-h-screen flex-col bg-[rgba(0,0,0,0.7)] bg-[url(/background.png)] bg-contain bg-fixed bg-center bg-repeat"
+	class="flex min-h-screen flex-col bg-[rgba(0,0,0,0.7)] bg-[url(/background.png)] bg-contain bg-fixed bg-center bg-repeat dark"
 	style="background-blend-mode: multiply;"
 >
 	<Navbar class="sticky top-0 z-20 w-full bg-[#22222D] py-1">


### PR DESCRIPTION
This pull request introduces a new dark mode variant to the application by adding a custom CSS variant and updating the layout to support it. The most important changes are detailed below:

### Dark Mode Support:

* [`src/app.css`](diffhunk://#diff-e269447b167c1d69748b9d5ccde405e2fb2d74af0d1832d5c05e63362816722dR7-R8): Added a `@custom-variant dark` to define the dark mode variant, allowing elements to adapt to a dark theme when the `.dark` class or its descendants are present.
* [`src/routes/(main)/+layout.svelte`](diffhunk://#diff-876bfbb5809b1ad12f3f87e7eb4816ea41a87c252f42ebdfeed688cd05cdb89cL12-R12): Updated the main layout's container to include the `dark` class, enabling the dark mode styles defined in the CSS.